### PR TITLE
[NPU] avoid HiFT linear interpolation device fault

### DIFF
--- a/cosyvoice/hifigan/generator.py
+++ b/cosyvoice/hifigan/generator.py
@@ -43,6 +43,27 @@ This code is modified from https://github.com/jik876/hifi-gan
 """
 
 
+def _linear_interpolate_1d_fallback(input: torch.Tensor, scale_factor: float) -> torch.Tensor:
+    input_size = input.shape[-1]
+    output_size = int(input_size * scale_factor)
+    source = (torch.arange(output_size, device=input.device, dtype=torch.float32) + 0.5) / scale_factor - 0.5
+    source = source.clamp(min=0)
+    lower = source.floor().to(torch.int64)
+    upper = (lower + 1).clamp(max=input_size - 1)
+    upper_weight = (source - lower).to(input.dtype)
+    lower_weight = 1 - upper_weight
+    return input.index_select(-1, lower) * lower_weight + input.index_select(-1, upper) * upper_weight
+
+
+def _linear_interpolate_1d(input: torch.Tensor, scale_factor: float) -> torch.Tensor:
+    if input.device.type != 'npu':
+        return F.interpolate(input, scale_factor=scale_factor, mode='linear')
+
+    # Ascend UpsampleLinear1d can fault on the large 480x downsampling used by
+    # CosyVoice3. Use equivalent tensor operations to keep computation on NPU.
+    return _linear_interpolate_1d_fallback(input, scale_factor)
+
+
 class ResBlock(torch.nn.Module):
     """Residual block module in HiFiGAN/BigVGAN."""
     def __init__(
@@ -248,9 +269,8 @@ class SineGen2(torch.nn.Module):
 
         # instantanouse phase sine[t] = sin(2*pi \sum_i=1 ^{t} rad)
         if not self.flag_for_pulse:
-            rad_values = torch.nn.functional.interpolate(rad_values.transpose(1, 2),
-                                                         scale_factor=1 / self.upsample_scale,
-                                                         mode="linear").transpose(1, 2)
+            rad_values = _linear_interpolate_1d(
+                rad_values.transpose(1, 2), scale_factor=1 / self.upsample_scale).transpose(1, 2)
 
             phase = torch.cumsum(rad_values, dim=1) * 2 * np.pi
             phase = torch.nn.functional.interpolate(phase.transpose(1, 2) * self.upsample_scale,

--- a/tests/test_hifigan_generator.py
+++ b/tests/test_hifigan_generator.py
@@ -1,0 +1,29 @@
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from cosyvoice.hifigan.generator import _linear_interpolate_1d_fallback
+
+
+class LinearInterpolate1dTest(unittest.TestCase):
+
+    def test_cosyvoice3_downsampling_coordinates(self):
+        input = torch.linspace(-1, 1, 6720 * 9).reshape(1, 6720, 9).transpose(1, 2)
+
+        expected = F.interpolate(input, scale_factor=1 / 480, mode='linear')
+        actual = _linear_interpolate_1d_fallback(input, scale_factor=1 / 480)
+
+        torch.testing.assert_close(actual, expected)
+
+    def test_cosyvoice3_upsampling_coordinates(self):
+        input = torch.linspace(-1, 1, 14 * 9).reshape(1, 14, 9).transpose(1, 2)
+
+        expected = F.interpolate(input, scale_factor=480, mode='linear')
+        actual = _linear_interpolate_1d_fallback(input, scale_factor=480)
+
+        torch.testing.assert_close(actual, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# [NPU] avoid HiFT linear interpolation device fault

## Motivation

CosyVoice3 HiFT inference fails on Ascend NPU with a `507015` AI Vector
exception. Device slog identifies the first failing kernel as
`UpsampleLinear1d_*_high_performance_2` with `VEC instruction error: the ub
address out of bounds`.

The failing call is the SineGen2 phase downsampling used by 24 kHz
CosyVoice3:

```text
input=(1, 9, 6720), float32, scale_factor=1/480, output=(1, 9, 14)
```

Making the input contiguous does not avoid the device fault.

## Modifications

- Keep the existing native `F.interpolate(..., mode="linear")` path for CPU,
  CUDA, and other devices.
- On NPU, express the same `align_corners=False` source coordinates using
  `index_select` and interpolation weights.
- Keep the entire fallback computation on the NPU; there is no CPU compute
  fallback.
- Add coordinate-equivalence tests for the real `6720 -> 14` downsampling and
  the reverse `14 -> 6720` scale.

## Correctness and runtime validation

- `6720 -> 14`: max absolute difference vs. CPU reference = `0`.
- `14 -> 6720`: max absolute difference = `1.19e-7`.
- Standalone HiFT with a real Flow mel tensor succeeds and returns
  `(1, 6720) float32`.
- SGLang-Omni `/v1/audio/speech` returns HTTP 200 and a valid PCM16 mono
  24 kHz WAV.
- Focused unit tests: `2 passed`.
- Repository flake8 configuration and `git diff --check`: passed.

## Scope

This is a model-side workaround for an Ascend built-in operator fault. It does
not claim to patch the internal CANN kernel implementation.

Related: sgl-project/sglang-omni#1652

